### PR TITLE
SPプロジェクトのSharedPtr連想配列システムをvoid*に変更。

### DIFF
--- a/ShaderProject/Object.cpp
+++ b/ShaderProject/Object.cpp
@@ -153,23 +153,23 @@ void CObjectManager::Destroy(CObject* obj)
 	m_destroy.push_back(obj);
 }
 
-void CObjectManager::DestroyAll(std::list<void*> sharedObjects)
+void CObjectManager::DestroyAll()
 {
 	auto itr = m_objects.begin();
 	while (itr != m_objects.end())
 	{
-		if ((*itr)->GetTagName() == "Camera")
-		{
-			itr++;
-			continue;
-		}
-		if ((*itr)->GetTagName() == "Player")
-		{
-			itr++;
-			continue;
-		}
 		delete (*itr);
-
+		*itr = nullptr;
 		itr = m_objects.erase(itr);
+	}
+}
+
+void CObjectManager::RemoveList(void* obj)
+{
+	CObject* ptr = (CObject*)obj;
+	auto result = std::find(m_objects.begin(), m_objects.end(), ptr);
+	if (result != m_objects.end())
+	{
+		m_objects.remove((CObject*)obj);
 	}
 }

--- a/ShaderProject/Object.h
+++ b/ShaderProject/Object.h
@@ -109,7 +109,10 @@ public:
 	void RemoveUpdate();
 	void Add(CObject* obj);
 	void Destroy(CObject* obj);
-	void DestroyAll(std::list<void*> sharedObjects);
+	void DestroyAll();
+
+	// Use in SceneBase ONLY.
+	void RemoveList(void* obj);
 private:
 	static CObjectManager* m_ins;
 public:

--- a/ShaderProject/SceneBase.cpp
+++ b/ShaderProject/SceneBase.cpp
@@ -11,13 +11,18 @@ SceneBase::SceneBase()
 }
 SceneBase::~SceneBase()
 {
-	std::list<void*> objects;
 	for (auto obj : m_objects)
 	{
-		void* ptr = obj.second.get();
-		objects.push_back(ptr);
+		if (obj.second != nullptr)
+		{
+			CObjectManager::GetIns()->RemoveList(obj.second);
+			delete obj.second;
+			obj.second = nullptr;
+		}
 	}
-	CObjectManager::GetIns()->DestroyAll(objects);
+	m_objects.clear();
+
+	CObjectManager::GetIns()->DestroyAll();
 	// サブシーンを削除
 	RemoveSubScene();
 
@@ -29,6 +34,7 @@ SceneBase::~SceneBase()
 		++it;
 	}
 	m_items.clear();
+	
 
 	// 親の参照を削除
 	if(m_pParent)

--- a/ShaderProject/SceneBase.hpp
+++ b/ShaderProject/SceneBase.hpp
@@ -8,26 +8,11 @@
 #include <Windows.h>
 #include "Object.h"
 
-// @brief シーン追加用オブジェクト
-class SceneObjectBase
-{
-public:
-	virtual ~SceneObjectBase() {}
-};
-template<class T>
-class SceneObject : public SceneObjectBase
-{
-public:
-	SceneObject(std::shared_ptr<T> ptr) : m_pObj(ptr) {}
-	virtual ~SceneObject() {}
-	std::shared_ptr<T> m_pObj;
-};
-
 // @breif シーン基本クラス
 class SceneBase
 {
 private:
-	using Objects = std::map<std::string, std::shared_ptr<SceneObjectBase>>;
+	using Objects = std::map<std::string, void*>;
 	using Items = std::list<std::string >;
 public:
 	SceneBase();
@@ -101,10 +86,10 @@ template<class T> T* SceneBase::CreateObj(const char* name)
 #endif // _DEBUG
 
 	// オブジェクト生成
-	std::shared_ptr<T> ptr = std::make_shared<T>();
-	m_objects.insert(std::pair<std::string, std::shared_ptr<SceneObjectBase>>(name, std::make_shared<SceneObject<T>>(ptr)));
+	T* ptr = new T;
+	m_objects.insert(std::pair<std::string, void*>(name, ptr));
 	m_items.push_back(name);
-	return ptr.get();
+	return ptr;
 }
 
 /// <summary>
@@ -120,8 +105,8 @@ template<class T> T* SceneBase::GetObj(const char* name)
 	if (it == m_objects.end()) return nullptr;
 
 	// 型変換
-	std::shared_ptr<SceneObject<T>> ptr = std::reinterpret_pointer_cast<SceneObject<T>>(it->second);
-	return ptr->m_pObj.get();
+	T* ptr = (T*)it->second;
+	return ptr;
 }
 
 #endif // __SCENE_BASE_HPP__


### PR DESCRIPTION
# 概要
Danmaku用に作成した全体Object管理システムとSPのシーンObject管理システムで解放が競合していたので修正。本来は一本化するべきなのだが、実装時間の都合上二本とも残すことにした。

## なぜシステムを変えるのか
- CObject管理システムによりObjectは解放される。
- が、SPシステム上で作成したものはShared_Ptrで作成されるため解放時エラーが起きていた。

## 対応案
- SPシステムに一本化
これが一番良い方法かと思う。うまくいくか未知数。
- 両立させ、CObject管理システム側をShared_ptr化
ベター。ちょっと時間がかかりそう。
- 両立させ、SPシステムを生ポインター化
パワー。すぐにできそう。

## 実装
- SPシステムを生ポインター化させることで対応。
    - SceneBaseのstd::map m_objects<std::string, std::shared_ptr<T>>を<std::string, T*>に変更。
    - CreateObj, GetObj等の関数をshared_ptrから生ポの実装に変更。
- 解放部分の変更
    - CObjectシステム側にListからRemoveさせる関数を追加。
    - SPシステム側で先に解放。
    - SPシステム側で解放したものをCObjectシステム側からRemove。
    - CObjectシステム側を解放
