### PR TITLE
F3で左上にデバッグ表示

### DIFF
--- a/ShaderProject/Assets/Texture/font.png
+++ b/ShaderProject/Assets/Texture/font.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0d08feae695bb77b2572505c1319cfab55dc04351d7d8a01e0722fe1647c454
+size 64650

--- a/ShaderProject/CollisionSystem.cpp
+++ b/ShaderProject/CollisionSystem.cpp
@@ -5,6 +5,8 @@
 #include "Input.h"
 #include "CameraBase.h"
 #include "Defines.h"
+#include "DebugText.h"
+
 CCollisionSystem* CCollisionSystem::Ins;
 CCollisionSystem* CCollisionSystem::GetIns()
 {
@@ -92,6 +94,8 @@ std::list<CCollisionSystem::Pair>* CCollisionSystem::GetList()
 	
 	GetChild(stackObj, 0);
 	DebugDrawPairLine();
+
+	DebugText::SetData(DebugText::SLOT_COLLISION, m_collisionPair.size());
 	return &m_collisionPair;
 }
 

--- a/ShaderProject/DebugText.cpp
+++ b/ShaderProject/DebugText.cpp
@@ -1,0 +1,85 @@
+#include "DebugText.h"
+#include "Sprite.h"
+#include "Input.h"
+namespace DebugText
+{
+	const std::string Header[SLOT_MAX] =
+	{
+		"FPS    :",
+		"PosX   :",
+		"PosY   :",
+		"Objects:",
+		"ColList:",
+	};
+	float g_datas[SLOT_MAX] = 
+	{
+		0,
+		0,
+		0,
+		0,
+		0,
+	};
+	Texture* g_texture;
+	bool g_enable = false;
+}
+void DebugText::Init()
+{
+	g_texture = new Texture;
+	g_texture->Create("Assets/Texture/font.png");
+}
+void DebugText::Update()
+{
+	if (IsKeyTrigger(VK_F3))
+	{
+		g_enable = !g_enable;
+	}
+}
+void DebugText::SetData(ESlot slot, float data)
+{
+	g_datas[slot] = data;
+}
+
+void DebugText::Draw()
+{
+	if (g_enable == false)
+	{
+		return;
+	}
+	const float uvSize = 1.0f / 16;
+	const float fontSize = 0.06f;
+	const float anchorX = -0.95f;
+	const float anchorY = 0.95f;
+	float posX = anchorX;
+	float posY = anchorY;
+	// make string
+	std::string str = {};
+	for (int i = 0; i < SLOT_MAX; i++)
+	{
+		str += Header[i] + std::to_string(g_datas[i]) + "\n";
+	}
+	const char* ptr = str.c_str();
+	Sprite::Reset();
+	Sprite::SetTexture(g_texture);
+	Sprite::SetUVScale(uvSize, uvSize);
+	Sprite::SetSize(fontSize, fontSize);
+	while (*ptr != '\0')
+	{
+		char uvX = *ptr & 0xf;
+		char uvY = (*ptr & 0xf0) >> 4;
+		Sprite::SetUVPos(uvX * uvSize, uvY * uvSize);
+		Sprite::SetOffset(posX, posY);
+		posX += fontSize * 0.4f;
+		if (*ptr == '\n')
+		{
+			posX = anchorX;
+			posY -= fontSize;
+		}
+		Sprite::Draw();
+		ptr++;
+	}
+	Sprite::SetOffset(0, 0);
+	Sprite::SetUVPos(0, 0);
+	Sprite::SetUVScale(1, 1);
+	Sprite::SetSize(1, 1);
+	Sprite::SetTexture(nullptr);
+}

--- a/ShaderProject/DebugText.h
+++ b/ShaderProject/DebugText.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <memory>
+
+
+namespace DebugText
+{
+	/*
+	FPS : xxx
+	PLX : -xxx.xxx
+	PLY :  xxx.xxx
+	OBJ	: xxx
+	*/
+	enum ESlot
+	{
+		SLOT_FPS,
+		SLOT_PLAYER_POS_X,
+		SLOT_PLAYER_POS_Y,
+		SLOT_OBJECTS,
+		SLOT_COLLISION,
+
+		SLOT_MAX
+	};
+	void Init();
+	void Update();
+	void SetData(ESlot slot, float data);
+	void Draw();
+}

--- a/ShaderProject/Object.cpp
+++ b/ShaderProject/Object.cpp
@@ -1,5 +1,6 @@
 #include "Object.h"
 #include "DebugWindow.hpp"
+#include "DebugText.h"
 CObject::CObject()
 {
 	m_collisionData.obj = this;
@@ -117,6 +118,7 @@ void CObjectManager::Update()
 		if (obj == nullptr) continue;
 		obj->UpdateBase();
 	}
+	DebugText::SetData(DebugText::SLOT_OBJECTS, m_objects.size());
 }
 
 // 全オブジェクトのドローを回す。描画マスクにより、スキップすることもある。

--- a/ShaderProject/Player.cpp
+++ b/ShaderProject/Player.cpp
@@ -3,6 +3,7 @@
 #include "ShotObj.h"
 #include "Wall.h"
 #include "CameraBase.h"
+#include "DebugText.h"
 
 #define PLAYER_SHOT_COLLIDER_SCALE (1.0f)
 
@@ -67,6 +68,8 @@ void CPlayer::Move()
 	{
 		m_rot.y = atan2f(-addPos.x, -addPos.z);
 	}
+	DebugText::SetData(DebugText::SLOT_PLAYER_POS_X, m_pos.x);
+	DebugText::SetData(DebugText::SLOT_PLAYER_POS_Y, m_pos.z);
 }
 
 void CPlayer::Shot()

--- a/ShaderProject/SceneRoot.cpp
+++ b/ShaderProject/SceneRoot.cpp
@@ -6,6 +6,8 @@
 #include "Input.h"
 #include "Geometory.h"
 
+#include "DebugText.h"
+
 #include "SceneK07.h"
 //--- ’è”’è‹`
 enum SceneKind
@@ -75,6 +77,9 @@ void SceneRoot::Init()
 	// ƒV[ƒ“‚Ìì¬
 	m_index = setting.index;
 	ChangeScene();
+
+	// debug text
+	DebugText::Init();
 }
 
 void SceneRoot::Uninit()
@@ -101,6 +106,8 @@ void SceneRoot::Uninit()
 
 void SceneRoot::Update(float tick)
 {
+	DebugText::SetData(DebugText::SLOT_FPS, 1.0f / tick);
+	DebugText::Update();
 #ifdef _DEBUG
 	if (IsKeyTrigger(VK_ESCAPE))
 	{
@@ -124,4 +131,6 @@ void SceneRoot::Draw()
 	pLight->Draw();
 
 	Geometory::DrawLines();
+
+	DebugText::Draw();
 }

--- a/ShaderProject/ShaderProject.vcxproj
+++ b/ShaderProject/ShaderProject.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="CameraBase.cpp" />
     <ClCompile Include="CollisionSystem.cpp" />
     <ClCompile Include="CsvLoader.cpp" />
+    <ClCompile Include="DebugText.cpp" />
     <ClCompile Include="DebugWindow.cpp" />
     <ClCompile Include="DirectX.cpp" />
     <ClCompile Include="DirectXMathUtil.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="CameraBase.h" />
     <ClInclude Include="CollisionSystem.h" />
     <ClInclude Include="CsvLoader.h" />
+    <ClInclude Include="DebugText.h" />
     <ClInclude Include="DebugWindow.hpp" />
     <ClInclude Include="Defines.h" />
     <ClInclude Include="DirectX.h" />

--- a/ShaderProject/ShaderProject.vcxproj.filters
+++ b/ShaderProject/ShaderProject.vcxproj.filters
@@ -162,6 +162,9 @@
     <ClCompile Include="EnemySpawner.cpp">
       <Filter>ソース ファイル\App\Base</Filter>
     </ClCompile>
+    <ClCompile Include="DebugText.cpp">
+      <Filter>ソース ファイル\System</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Defines.h">
@@ -262,6 +265,9 @@
     </ClInclude>
     <ClInclude Include="CsvLoader.h">
       <Filter>ヘッダー ファイル\App\Base</Filter>
+    </ClInclude>
+    <ClInclude Include="DebugText.h">
+      <Filter>ヘッダー ファイル\System</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# 概要
- F3キーで左上に以下の情報がデバッグ表示されるように。
    - FPS
    - PlayerPosX
    - PlayerPosY
    - Objectの総数
    - 当たり判定リストの総数

# 詳細
![image](https://github.com/Keisuke0619/Danmaku02/assets/97930653/1c688600-d697-469d-b383-0ff57b43fbc4)
F3キーを押すとデバッグ表示のON/OFFを切り替えられます。
DebugText.hのEnumとCppのHeader配列等をいじったうえで、適切な場所からSetData関数を呼べばすぐに拡張できます。
今後はLogも出せるようにしたい。