### PR TITLE
タイトルシーンとシーンチェンジ機構

### DIFF
--- a/ShaderProject/Assets/Texture/UI/Pause_Back.png
+++ b/ShaderProject/Assets/Texture/UI/Pause_Back.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5824142948f40f3cff46144949c7366688fc198ebbb08ab941f4c929c0e5140
-size 4014
+oid sha256:d78a857a16556cfd7a6551508accf8e1268f28d604e64bddd4cfcdde964a7e3c
+size 15147

--- a/ShaderProject/Assets/Texture/UI/Title_Back.png
+++ b/ShaderProject/Assets/Texture/UI/Title_Back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c52e7cc492fd78c2f95378e43a97f13ad9aa2322509593861f0e53b54439514
+size 10734

--- a/ShaderProject/EventCallback.h
+++ b/ShaderProject/EventCallback.h
@@ -1,5 +1,11 @@
 #pragma once
 
+enum EEventID
+{
+	EVENT_FINISH_EVENT_CAMERA,
+	EVENT_CLOSE_PAUSE_WINDOW,
+};
+
 class IEventCallBack
 {
 public:

--- a/ShaderProject/SceneK07.cpp
+++ b/ShaderProject/SceneK07.cpp
@@ -226,12 +226,12 @@ void SceneK07::DrawSky()
 
 void SceneK07::CallBack(int eventID)
 {
-	if (eventID == 0)
+	if (eventID == EVENT_FINISH_EVENT_CAMERA)
 	{
 		auto defaultCamera = GetObj<CameraBase>("MainCamera");
 		CameraBase::SetPrimary(defaultCamera);
 	}
-	if (eventID == 1)
+	if (eventID == EVENT_CLOSE_PAUSE_WINDOW)
 	{
 		m_pause = false;
 	}

--- a/ShaderProject/ScenePause.cpp
+++ b/ShaderProject/ScenePause.cpp
@@ -29,6 +29,7 @@ void CScenePause::Draw()
 {
 	Sprite::Reset();
 	Sprite::SetTexture(m_back);
+	Sprite::SetSize(2, 2);
 	Sprite::Draw();
 	Sprite::Reset();
 }

--- a/ShaderProject/SceneRoot.cpp
+++ b/ShaderProject/SceneRoot.cpp
@@ -9,6 +9,7 @@
 #include "DebugText.h"
 
 #include "SceneK07.h"
+#include "SceneTitle.h"
 //--- íËêîíËã`
 enum SceneKind
 {
@@ -31,14 +32,21 @@ struct ViewSetting
 	int index;
 };
 
-void SceneRoot::ChangeScene()
+void SceneRoot::SetNextScene(ESceneID id)
 {
-	switch (m_index)
+	m_nextSceneID = id;
+}
+
+void SceneRoot::SceneChange()
+{
+	RemoveSubScene();
+	switch (m_nextSceneID)
 	{
-	default:
-	case SCENE_K07: AddSubScene<SceneK07>(); break;
-	case SCENE_K00: AddSubScene<SceneK07>(); break;
+	case SCENE_GAME: AddSubScene<SceneK07>(); break;
+	case SCENE_TITLE: AddSubScene<CSceneTitle>(); break;
 	}
+
+	m_nextSceneID = SCENE_NONE;
 }
 
 const char* SettingFileName = "Assets/setting.dat";
@@ -77,7 +85,7 @@ void SceneRoot::Init()
 
 	// ÉVÅ[ÉìÇÃçÏê¨
 	m_index = setting.index;
-	ChangeScene();
+	SetNextScene(SCENE_GAME);
 
 	
 }
@@ -113,9 +121,11 @@ void SceneRoot::Update(float tick)
 	pLight->Update();
 	if (IsKeyTrigger('N'))
 	{
-		//MeshPool::Ins()->DeleteAll();
-		RemoveSubScene();
-		ChangeScene();
+		SetNextScene(SCENE_GAME);
+	}
+	if (m_nextSceneID != SCENE_NONE)
+	{
+		SceneChange();
 	}
 }
 void SceneRoot::Draw()

--- a/ShaderProject/SceneRoot.h
+++ b/ShaderProject/SceneRoot.h
@@ -2,20 +2,29 @@
 #define __SCENE_ROOT_H__
 
 #include "SceneBase.hpp"
+#include "EventCallback.h"
 
 class SceneRoot : public SceneBase
 {
+public:
+	enum ESceneID
+	{
+		SCENE_TITLE,
+		SCENE_GAME,
+		SCENE_RESULT,
+		SCENE_NONE
+	};
 public:
 	void Init();
 	void Uninit();
 	void Update(float tick);
 	void Draw();
-
-private:
-	void ChangeScene();
+	void SetNextScene(ESceneID id);
 
 private:
 	int m_index;
+	ESceneID m_nextSceneID;
+	void SceneChange();
 };
 
 #endif // __SCENE_ROOT_H__

--- a/ShaderProject/SceneTitle.cpp
+++ b/ShaderProject/SceneTitle.cpp
@@ -1,0 +1,28 @@
+#include "SceneTitle.h"
+#include "Input.h"
+#include "SceneRoot.h"
+#include "Texture.h"
+void CSceneTitle::Init()
+{
+	m_back = new Texture();
+	m_back->Create("Assets/Texture/UI/Title_back.png");
+}
+
+void CSceneTitle::Uninit()
+{
+}
+
+void CSceneTitle::Update(float tick)
+{
+	if (IsKeyTrigger(VK_RETURN))
+	{
+		((SceneRoot*)m_pParent)->SetNextScene(SceneRoot::SCENE_GAME);
+	}
+}
+
+void CSceneTitle::Draw()
+{
+	Sprite::SetTexture(m_back);
+	Sprite::SetSize(2, 2);
+	Sprite::Draw();
+}

--- a/ShaderProject/SceneTitle.h
+++ b/ShaderProject/SceneTitle.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <SceneBase.hpp>
+#include <Sprite.h>
+class CSceneTitle : public SceneBase
+{
+public:
+	void Init() override;
+	void Uninit() override;
+	void Update(float tick) override;
+	void Draw() override;
+private:
+	Texture* m_back;
+};

--- a/ShaderProject/ShaderProject.vcxproj
+++ b/ShaderProject/ShaderProject.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="DirectXMathUtil.cpp" />
     <ClCompile Include="InclutionShot.cpp" />
     <ClCompile Include="ScenePause.cpp" />
+    <ClCompile Include="SceneTitle.cpp" />
     <ClCompile Include="Util.cpp" />
     <ClCompile Include="Enemy.cpp" />
     <ClCompile Include="EnemySpawner.cpp" />
@@ -225,6 +226,7 @@
     <ClInclude Include="DirectXMathUtil.h" />
     <ClInclude Include="InclutionShot.h" />
     <ClInclude Include="ScenePause.h" />
+    <ClInclude Include="SceneTitle.h" />
     <ClInclude Include="Util.h" />
     <ClInclude Include="Enemy.h" />
     <ClInclude Include="EnemySpawner.h" />

--- a/ShaderProject/ShaderProject.vcxproj.filters
+++ b/ShaderProject/ShaderProject.vcxproj.filters
@@ -183,6 +183,12 @@
     <ClCompile Include="BossStage01.cpp">
       <Filter>ソース ファイル\App\Objects</Filter>
     </ClCompile>
+    <ClCompile Include="ScenePause.cpp">
+      <Filter>ソース ファイル\App\Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneTitle.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Defines.h">
@@ -301,6 +307,12 @@
     </ClInclude>
     <ClInclude Include="InclutionShot.h">
       <Filter>ヘッダー ファイル\App\Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="ScenePause.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneTitle.h">
+      <Filter>ヘッダー ファイル\App\Scene</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# 概要
タイトルシーン（仮）の作成
ルートシーンにシーンチェンジ機構の実装

# 詳細
SceneBaseを継承したCSceneTitleクラスの作成。
後ほどこのクラスにタイトルのふるまいを実装していく。
SceneRootにシーンチェンジ機構を実装。
SetNextSceneで次のシーンを予約し、アップデートの最後でシーン遷移を行う。（予約せずに直で変更すると現シーンが解放される関係で関数から戻ったタイミングでアクセス違反が起きる）